### PR TITLE
Update target frameworks for plugin and test project.

### DIFF
--- a/src/Npgsql.CrateDb/Npgsql.CrateDb.csproj
+++ b/src/Npgsql.CrateDb/Npgsql.CrateDb.csproj
@@ -7,7 +7,7 @@
     <Copyright>Copyright 2018 © Crate.io</Copyright>
     <Company>Crate.io</Company>
     <PackageTags>npgsql crate cratedb ado ado.net database sql</PackageTags>
-    <TargetFrameworks>net45;net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <WarningsAsErrors>true</WarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageProjectUrl>https://github.com/crate/crate-npgsql</PackageProjectUrl>

--- a/test/Npgsql.CrateDbTests/Npgsql.CrateDbTests.csproj
+++ b/test/Npgsql.CrateDbTests/Npgsql.CrateDbTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netcoreapp1.0'">Full</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
Remove support for net45 and net451 and target net452 instead. This is in line with the following commit of the npgsql team: https://github.com/npgsql/npgsql/commit/91d23f90ef00eadc7c07966833959a5b3f877127