### PR TITLE
Changed mapping for geo_point to npgsql point datatype (oid 600)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changes in Npgsql-Plugin for Crate
 Unreleased
 ==========
 
+-  Added a type mapping from ``geo_point`` (oid 600) to ``NpgsqlPoint``, to be
+   able to handle ``geo_point`` values with CrateDB >= 4.1. There the streaming
+   changed, so that ``geo_point`` values are no longer streamed as double array
+   but as ``geo_point``.
+
 2018/10/15 1.2.3
 ================
 

--- a/src/Npgsql.CrateDb/CrateDbDatabaseInfo.cs
+++ b/src/Npgsql.CrateDb/CrateDbDatabaseInfo.cs
@@ -28,7 +28,8 @@ namespace Npgsql.CrateDb
             { "int8", 20 },
             { "timestamptz", 1184 },
             { "float8", 701 },
-            { "varchar", 1043 }
+            { "varchar", 1043 },
+            { "point", 600 }
         };
 
         static readonly IDictionary<string, uint> CrateDbArrayTypes = new Dictionary<string, uint>
@@ -42,7 +43,8 @@ namespace Npgsql.CrateDb
             { "_int8", 1016 },
             { "_timestamptz", 1185 },
             { "_float8", 1022 },
-            { "_varchar", 1015 }
+            { "_varchar", 1015 },
+            { "_point", 1017 }
         };
 
         static readonly IDictionary<string, string> PgTypeNameToInternalName = new Dictionary<string, string>
@@ -71,7 +73,7 @@ namespace Npgsql.CrateDb
             {
                 Version = v;
             }
-            
+
             HasIntegerDateTimes = conn.PostgresParameters.TryGetValue("integer_datetimes", out var intDateTimes) &&
                 intDateTimes == "on";
         }


### PR DESCRIPTION
Fixed and extended unit tests

Please verify correct mapping for point. 
Before it was double[] and now to Npgsql datatype point