### PR TITLE
Fix object array type test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: python
 cache: pip
 python:
-  - 3.6
+  - 3.7
 sudo:
   false
 install:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-# travis and jenkins have python3.4 installed
-if hash python3.4 2> /dev/null; then
-    python3.4 -m venv .venv --without-pip
+if hash python3.7 2> /dev/null; then
+    python3.7 -m venv .venv --without-pip
     curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
     .venv/bin/python get-pip.py
 elif hash python3 2> /dev/null; then
-    # fallback for dev machines, this should be >= 3.3
+    # fallback to python3 in case there is no python3.7
     python3 -m venv .venv
 else
     echo 'python3 required'

--- a/test/Npgsql.CrateDbTests/CrateDbTypesTest.cs
+++ b/test/Npgsql.CrateDbTests/CrateDbTypesTest.cs
@@ -449,9 +449,18 @@ namespace Npgsql.CrateDbTests
             {
                 var r = cmd.ExecuteScalar();
 
-                Assert.That(r, Is.InstanceOf(typeof(string)));
+                TestObject[] objArr;
+                if (con.PostgreSqlVersion >= new Version("4.1.0"))
+                {
+                    Assert.That(r, Is.InstanceOf(typeof(string[])));
+                    objArr = ((string[])r).Select(s => Newtonsoft.Json.JsonConvert.DeserializeObject<TestObject>(s)).ToArray();
+                }
+                else
+                {
+                    Assert.That(r, Is.InstanceOf(typeof(string)));
+                    objArr = Newtonsoft.Json.JsonConvert.DeserializeObject<TestObject[]>((string)r);
+                }
 
-                var objArr = Newtonsoft.Json.JsonConvert.DeserializeObject<TestObject[]>((string)r);
                 Assert.That(objArr, Is.EquivalentTo(new TestObject[]
                 {
                     new TestObject { inner = "Zoon1" },


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

CrateDB >= 4.1.0 maps the `array(object)` data type to
the `PGArray(JSON)` instead of `JSON` Postgres type.
Therefore, the test case has to be adjusted.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
