### PR TITLE
Doc: Add SSL Mode to connect example

### DIFF
--- a/docs/connect.txt
+++ b/docs/connect.txt
@@ -29,7 +29,7 @@ Connect to CrateDB using a standard `NpgsqlConnection`_ object, like so:
 
 .. code-block:: csharp
 
-    var connString = "Host=127.0.0.1;Username=crate";
+    var connString = "Host=127.0.0.1;Username=crate;SSL Mode=Prefer";
 
     using (var conn = new NpgsqlConnection(connString))
     {


### PR DESCRIPTION
`Prefer` works both for SSL enabled servers and servers without. That's
better suited for a getting started example, as it reduces the chance of
people running into connection issues because of SSL.