### PR TITLE
Documentation: Improve notes about vanilla Npgsql driver

### DIFF
--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -6,12 +6,13 @@ Connect to CrateDB
 
 Connect to CrateDB using the :ref:`CrateDB Npgsql Plugin <index>`.
 
-.. NOTE::
+CAUTION::
 
-    Please note that this driver is not recommended with recent releases of
-    CrateDB >= 4.2, which works fine with the vanilla Npgsql driver. See
-    also :ref:`index`.
+    For CrateDB versions 4.2 and above, we recommend that you use the `stock
+    Npgsql driver` instead of this one.
 
+    This software is a legacy plugin for older versions of CrateDB that lacked
+    full compatibility with Npgsql.
 
 .. rubric:: Table of contents
 

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -6,6 +6,13 @@ Connect to CrateDB
 
 Connect to CrateDB using the :ref:`CrateDB Npgsql Plugin <index>`.
 
+.. NOTE::
+
+    Please note that this driver is not recommended with recent releases of
+    CrateDB >= 4.2, which works fine with the vanilla Npgsql driver. See
+    also :ref:`index`.
+
+
 .. rubric:: Table of contents
 
 .. contents::

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -68,8 +68,9 @@ Use the standard `Npgsql documentation`_ for the rest of your setup process.
 
     The plugin :ref:`data-types` appendix.
 
-.. _Npgsql documentation: https://www.npgsql.org/doc/index.html
 .. _connection string parameters: https://www.npgsql.org/doc/connection-string-parameters.html
 .. _DatabaseInfoFactory: https://www.npgsql.org/doc/api/Npgsql.NpgsqlDatabaseInfo.html
-.. _usual Npgsql way: https://www.npgsql.org/doc/index.html
 .. _NpgsqlConnection: https://www.npgsql.org/doc/api/Npgsql.NpgsqlConnection.html
+.. _Npgsql documentation: https://www.npgsql.org/doc/index.html
+.. _stock Npgsql driver: https://www.npgsql.org/
+.. _usual Npgsql way: https://www.npgsql.org/doc/index.html

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -6,6 +6,13 @@ Getting started
 
 Install and get started with the :ref:`CrateDB Npgsql Plugin <index>`.
 
+.. NOTE::
+
+    Please note that this driver is not recommended with recent releases of
+    CrateDB >= 4.2, which works fine with the vanilla Npgsql driver. See
+    also :ref:`index`.
+
+
 .. rubric:: Table of contents
 
 .. contents::
@@ -31,7 +38,7 @@ the appropriate Nuget instructions to get the plugin installed.
 .. NOTE::
 
     If you're using a generic database program that can work with any ADO.NET
-    provider but doesn't come with Npgsql or reference it directly, you can
+    provider but doesn't come with Npgsql or references it directly, you can
     install Npgsql with the CrateDB plugin into your `Global Assembly Cache`_
     (GAC) with our custom `Npgsql Installer`_.
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -6,12 +6,13 @@ Getting started
 
 Install and get started with the :ref:`CrateDB Npgsql Plugin <index>`.
 
-.. NOTE::
+CAUTION::
 
-    Please note that this driver is not recommended with recent releases of
-    CrateDB >= 4.2, which works fine with the vanilla Npgsql driver. See
-    also :ref:`index`.
+    For CrateDB versions 4.2 and above, we recommend that you use the `stock
+    Npgsql driver` instead of this one.
 
+    This software is a legacy plugin for older versions of CrateDB that lacked
+    full compatibility with Npgsql.
 
 .. rubric:: Table of contents
 
@@ -48,11 +49,12 @@ Next steps
 Once the plugin is installed, you probably want to :ref:`connect to CrateDB
 <connect>`.
 
-.. _Npgsql.CrateDB Nuget package: https://www.nuget.org/packages/Npgsql.CrateDb/
 .. _dotnet CLI: https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-using-the-dotnet-cli
 .. _fork: https://github.com/crate/npgsql
 .. _Global Assembly Cache: https://docs.microsoft.com/en-us/dotnet/framework/app-domains/gac
 .. _introduction to Nuget: https://docs.microsoft.com/en-us/nuget/what-is-nuget
+.. _Npgsql.CrateDB Nuget package: https://www.nuget.org/packages/Npgsql.CrateDb/
 .. _Npgsql Installer: https://cdn.crate.io/downloads/releases/npgsql/
 .. _Npgsql project: https://github.com/npgsql/npgsql
+.. _stock Npgsql driver: https://www.npgsql.org/
 .. _Visual Studio: https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -22,8 +22,8 @@ CAUTION::
 Install
 =======
 
-The Npgsql plugin is made available as `Npgsql.CrateDB Nuget package`_. Follow
-the appropriate Nuget instructions to get the plugin installed.
+The Npgsql plugin is made available as a NuGet package `Npgsql.CrateDb`_. Follow
+the appropriate NuGet instructions to get the plugin installed.
 
 .. NOTE::
 
@@ -32,9 +32,9 @@ the appropriate Nuget instructions to get the plugin installed.
 
 .. SEEALSO::
 
-    An `introduction to Nuget`_.
+    An `introduction to NuGet`_.
 
-    Nuget instructions for `dotnet CLI`_ or `Visual Studio`_.
+    NuGet instructions for `dotnet CLI`_ or `Visual Studio`_.
 
 .. NOTE::
 
@@ -49,11 +49,12 @@ Next steps
 Once the plugin is installed, you probably want to :ref:`connect to CrateDB
 <connect>`.
 
+
 .. _dotnet CLI: https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-using-the-dotnet-cli
 .. _fork: https://github.com/crate/npgsql
 .. _Global Assembly Cache: https://docs.microsoft.com/en-us/dotnet/framework/app-domains/gac
-.. _introduction to Nuget: https://docs.microsoft.com/en-us/nuget/what-is-nuget
-.. _Npgsql.CrateDB Nuget package: https://www.nuget.org/packages/Npgsql.CrateDb/
+.. _introduction to NuGet: https://docs.microsoft.com/en-us/nuget/what-is-nuget
+.. _Npgsql.CrateDb: https://www.nuget.org/packages/Npgsql.CrateDb/
 .. _Npgsql Installer: https://cdn.crate.io/downloads/releases/npgsql/
 .. _Npgsql project: https://github.com/npgsql/npgsql
 .. _stock Npgsql driver: https://www.npgsql.org/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ demonstration program for using CrateDB with vanilla Npgsql`_.
     The CrateDB Npgsql Plugin is an open source project and it is hosted on
     GitHub at `crate-npgsql`_.
 
+.. _basic demonstration program for using CrateDB with vanilla Npgsql: https://github.com/crate/cratedb-examples/tree/main/spikes/npgsql-vanilla
 .. _Crate.io: http://crate.io/
 .. _CrateDB: https://crate.io/docs/crate/reference/
 .. _crate-npgsql: https://github.com/crate/crate-npgsql
@@ -40,4 +41,3 @@ demonstration program for using CrateDB with vanilla Npgsql`_.
 .. _Npgsql: https://www.npgsql.org/
 .. _Npgsql documentation: https://www.npgsql.org/doc/index.html
 .. _Npgsql.CrateDb: https://www.nuget.org/packages/Npgsql.CrateDb/
-.. _basic demonstration program for using CrateDB with vanilla Npgsql: https://github.com/crate/cratedb-examples/tree/main/spikes/npgsql-vanilla

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,24 +4,20 @@
 CrateDB Npgsql Plug-In
 ======================
 
-A `.NET`_ plugin for `Npgsql`_ that provides backwards compatibility support
-for `CrateDB`_ versions 4.1.x and earlier. 
 
-.. WARNING::
+.. CAUTION::
 
-   CrateDB versions 4.2 and later work with `Npgsql`_ without the need for a plugin.
+    Please don't use this driver with recent versions of CrateDB.
 
-.. NOTE::
+    CrateDB versions prior to 4.2 needed a custom fork of the official `Npgsql`_
+    `.NET`_ data provider for PostgreSQL, `Npgsql.CrateDb`_. CrateDB versions
+    4.2 and later work with the vanilla Npgsql driver without the need for a
+    plugin.
 
-    This is a basic plugin reference.
+For general help using Npgsql, please consult the standard `Npgsql
+documentation`_. For quickly getting started, please also consult the `basic
+demonstration program for using CrateDB with vanilla Npgsql`_.
 
-    For general help using Npgsql, please consult the standard `Npgsql
-    documentation`_.
-
-.. SEEALSO::
-
-    The CrateDB Npgsql Plugin is an open source project and is `hosted on
-    GitHub`_.
 
 .. rubric:: Table of contents
 
@@ -32,9 +28,16 @@ for `CrateDB`_ versions 4.1.x and earlier.
    connect
    appendices/index
 
-.. _Npgsql: https://www.npgsql.org/
-.. _.NET: https://www.microsoft.com/net
+.. SEEALSO::
+
+    The CrateDB Npgsql Plugin is an open source project and it is hosted on
+    GitHub at `crate-npgsql`_.
+
 .. _Crate.io: http://crate.io/
-.. _Npgsql documentation: https://www.npgsql.org/doc/index.html
 .. _CrateDB: https://crate.io/docs/crate/reference/
-.. _hosted on GitHub: https://github.com/crate/crate-npgsql/
+.. _crate-npgsql: https://github.com/crate/crate-npgsql
+.. _.NET: https://www.microsoft.com/net
+.. _Npgsql: https://www.npgsql.org/
+.. _Npgsql documentation: https://www.npgsql.org/doc/index.html
+.. _Npgsql.CrateDb: https://www.nuget.org/packages/Npgsql.CrateDb/
+.. _basic demonstration program for using CrateDB with vanilla Npgsql: https://github.com/crate/cratedb-examples/tree/main/spikes/npgsql-vanilla

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,17 +5,17 @@ CrateDB Npgsql Plug-In
 ======================
 
 
-.. CAUTION::
+CAUTION::
 
-    Please don't use this driver with recent versions of CrateDB.
+    For CrateDB versions 4.2 and above, we recommend that you use the `stock
+    Npgsql driver` instead of this one.
 
-    CrateDB versions prior to 4.2 needed a custom fork of the official `Npgsql`_
-    `.NET`_ data provider for PostgreSQL, `Npgsql.CrateDb`_. CrateDB versions
-    4.2 and later work with the vanilla Npgsql driver without the need for a
-    plugin.
+    This software, is a legacy plugin for older versions of CrateDB that lacked
+    full compatibility with Npgsql.
 
-For general help using Npgsql, please consult the standard `Npgsql
-documentation`_. For quickly getting started, please also consult the `basic
+For general help using the official `Npgsql`_ `.NET`_ data provider for
+PostgreSQL, please consult the standard `Npgsql documentation`_.
+For quickly getting started, please also consult the `basic
 demonstration program for using CrateDB with vanilla Npgsql`_.
 
 
@@ -40,4 +40,4 @@ demonstration program for using CrateDB with vanilla Npgsql`_.
 .. _.NET: https://www.microsoft.com/net
 .. _Npgsql: https://www.npgsql.org/
 .. _Npgsql documentation: https://www.npgsql.org/doc/index.html
-.. _Npgsql.CrateDb: https://www.nuget.org/packages/Npgsql.CrateDb/
+.. _stock Npgsql driver: https://www.npgsql.org/


### PR DESCRIPTION
Hi there,

in order to improve navigation and reduce confusion, this patch tries to emphasize the fact that starting with CrateDB 4.2, the vanilla Npgsql driver should be used.

The origin of this patch is that we should recognize that people are apparently still confused about using the vanilla Npgsql driver and instead use the CrateDB fork, see https://community.crate.io/t/how-to-connect-npgsqldatabaseinfo-for-crate-database-in-c/698.

With kind regards,
Andreas.
