### PR TITLE
Documentation: Fix broken link to example using the vanilla Npgsql driver

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ demonstration program for using CrateDB with vanilla Npgsql`_.
     The CrateDB Npgsql Plugin is an open source project and it is hosted on
     GitHub at `crate-npgsql`_.
 
-.. _basic demonstration program for using CrateDB with vanilla Npgsql: https://github.com/crate/cratedb-examples/tree/main/spikes/npgsql-vanilla
+.. _basic demonstration program for using CrateDB with vanilla Npgsql: https://github.com/crate/cratedb-examples/tree/main/by-language/csharp-npgsql
 .. _Crate.io: http://crate.io/
 .. _CrateDB: https://crate.io/docs/crate/reference/
 .. _crate-npgsql: https://github.com/crate/crate-npgsql


### PR DESCRIPTION
This patch accompanies https://github.com/crate/cratedb-examples/commit/5f9960992, which reorganized the folder layout of the `cratedb-examples` repository.
