### PR TITLE
CI: Update from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-22.04"]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## About

CI became defunct because ubuntu-20.04 was retired, and we didn't know because scheduled tasks have been hibernated.
